### PR TITLE
Add requires.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Requirements Status](https://requires.io/github/tnir/requires-io-poc-1/requirements.svg?branch=master)](https://requires.io/github/tnir/requires-io-poc-1/requirements/?branch=master)
+
 # requires-io-poc-1
 PoC 1 of requires.io


### PR DESCRIPTION
Requires.io badge helps product/release manager(s) to find outdated and insecure pypi packages.